### PR TITLE
feature/14_category_filter

### DIFF
--- a/frontend/app/home/home.module.css
+++ b/frontend/app/home/home.module.css
@@ -29,6 +29,7 @@
   gap: 0.6rem;
   color: #1f1f1f;
   font-size: 12px;
+  cursor: pointer;
 }
 
 .categoryActive {

--- a/frontend/app/home/page.tsx
+++ b/frontend/app/home/page.tsx
@@ -10,6 +10,9 @@ import styles from "./home.module.css";
 export default function HomePage() {
   const [categories, setCategories] = useState<NoteCategory[]>([]);
   const [notes, setNotes] = useState<NoteItem[]>([]);
+  const [selectedCategoryId, setSelectedCategoryId] = useState<number | null>(
+    null,
+  );
   const [status, setStatus] = useState("");
 
   useEffect(() => {
@@ -49,18 +52,36 @@ export default function HomePage() {
   }, [categories, notes]);
 
   const totalNotes = useMemo(() => notes.length, [notes]);
+  const filteredNotes = useMemo(() => {
+    if (selectedCategoryId === null) {
+      return notes;
+    }
+
+    return notes.filter((note) => note.category.id === selectedCategoryId);
+  }, [notes, selectedCategoryId]);
 
   return (
     <main className={styles.screen}>
       <section className={styles.shell}>
         <aside className={styles.sidebar}>
           <ul>
-            <li className={styles.categoryActive}>
+            <li
+              className={
+                selectedCategoryId === null ? styles.categoryActive : ""
+              }
+              onClick={() => setSelectedCategoryId(null)}
+            >
               All Categories
               <span className={styles.categoryCount}>{totalNotes}</span>
             </li>
             {categories.map((category) => (
-              <li key={category.id}>
+              <li
+                key={category.id}
+                className={
+                  selectedCategoryId === category.id ? styles.categoryActive : ""
+                }
+                onClick={() => setSelectedCategoryId(category.id)}
+              >
                 <span
                   aria-hidden="true"
                   className={styles.dot}
@@ -85,10 +106,10 @@ export default function HomePage() {
           {status ? <p className={styles.status}>{status}</p> : null}
 
           <div className={styles.notesGrid}>
-            {notes.length === 0 ? (
+            {filteredNotes.length === 0 ? (
               <EmptyNotesScreen />
             ) : (
-              notes.map((note) => (
+              filteredNotes.map((note) => (
                 <RegularNote
                   key={note.id}
                   category={note.category.name}


### PR DESCRIPTION
This pull request enhances the category filtering experience in the notes app sidebar and improves the user interface for category selection. The most significant changes include adding interactive category selection in the sidebar and updating the notes list to reflect the selected category.

**Category filtering and sidebar interaction improvements:**

* Added a `selectedCategoryId` state to track which category is selected, enabling filtering of notes by category in the sidebar.
* Updated the sidebar to highlight the active category and allow users to click on categories (including "All Categories") to filter notes. The active category is visually distinguished, and clicking updates the `selectedCategoryId`.
* Added a `cursor: pointer` style to sidebar category items to indicate they are clickable.

**Notes display updates:**

* Introduced a `filteredNotes` variable to show only notes from the selected category. The notes grid now displays `filteredNotes` instead of all notes, and the empty state is shown if no notes match the filter. [[1]](diffhunk://#diff-10c53518baaaf28bc3ededc73516066912792177159adb3ec5078667d4c5a29eR55-R84) [[2]](diffhunk://#diff-10c53518baaaf28bc3ededc73516066912792177159adb3ec5078667d4c5a29eL88-R112)