### PR TITLE
Feature/20_cache_categories

### DIFF
--- a/backend/api/apps.py
+++ b/backend/api/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class ApiConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "api"
+
+    def ready(self):
+        from api import signals  # noqa: F401

--- a/backend/api/cache/category_cache.py
+++ b/backend/api/cache/category_cache.py
@@ -1,0 +1,35 @@
+from django.core.cache import cache
+
+CATEGORY_CACHE_TTL_SECONDS = 60 * 60 * 24
+CATEGORY_CACHE_VERSION_KEY = "categories_cache_version"
+
+
+def get_category_cache_version() -> int:
+    version = cache.get(CATEGORY_CACHE_VERSION_KEY)
+    if version is None:
+        cache.add(CATEGORY_CACHE_VERSION_KEY, 1, CATEGORY_CACHE_TTL_SECONDS)
+        return 1
+    return int(version)
+
+
+def get_categories_payload_cache_key(*, user_id: int) -> str:
+    version = get_category_cache_version()
+    return f"categories:user:{user_id}:v:{version}"
+
+
+def bump_category_cache_version() -> None:
+    try:
+        cache.incr(CATEGORY_CACHE_VERSION_KEY)
+        return
+    except ValueError:
+        cache.set(CATEGORY_CACHE_VERSION_KEY, 2, CATEGORY_CACHE_TTL_SECONDS)
+        return
+    except NotImplementedError:
+        pass
+
+    current = get_category_cache_version()
+    cache.set(
+        CATEGORY_CACHE_VERSION_KEY,
+        current + 1,
+        CATEGORY_CACHE_TTL_SECONDS,
+    )

--- a/backend/api/signals.py
+++ b/backend/api/signals.py
@@ -1,0 +1,11 @@
+from django.db.models.signals import post_delete, post_save
+from django.dispatch import receiver
+
+from api.cache.category_cache import bump_category_cache_version
+from api.models import Category
+
+
+@receiver(post_save, sender=Category)
+@receiver(post_delete, sender=Category)
+def invalidate_categories_cache_on_category_change(**kwargs):
+    bump_category_cache_version()

--- a/backend/api/tests/test_categories_api.py
+++ b/backend/api/tests/test_categories_api.py
@@ -1,8 +1,12 @@
 import pytest
 from django.contrib.auth import get_user_model
+from django.core.cache import cache
 from django.urls import reverse
 
+from api.cache import category_cache
+from api.cache.category_cache import CATEGORY_CACHE_VERSION_KEY
 from api.models import Category
+from api.views import category as category_views
 
 
 @pytest.mark.django_db
@@ -45,3 +49,61 @@ def test_categories_collection_returns_shared_and_user_owned_categories(
     assert "Personal" in names
     assert "Work" in names
     assert "Other private" not in names
+
+
+@pytest.mark.django_db
+def test_categories_collection_uses_cached_payload(client, monkeypatch):
+    cache.clear()
+    user_model = get_user_model()
+    user = user_model.objects.create_user("cached", password="strong-pass-123")
+    client.force_login(user)
+
+    first_response = client.get(reverse("categories-collection"))
+    assert first_response.status_code == 200
+
+    def fail_if_called(_):
+        raise AssertionError(
+            "Expected cached response, but service was called."
+        )
+
+    monkeypatch.setattr(
+        category_views,
+        "list_categories_for_user",
+        fail_if_called,
+    )
+
+    second_response = client.get(reverse("categories-collection"))
+    assert second_response.status_code == 200
+    assert second_response.json() == first_response.json()
+
+
+@pytest.mark.django_db
+def test_category_create_bumps_categories_cache_version():
+    cache.clear()
+    cache.set(CATEGORY_CACHE_VERSION_KEY, 1)
+
+    Category.objects.create(
+        name="Drama",
+        color="#A8C686",
+        owner=None,
+        is_default=False,
+    )
+
+    assert cache.get(CATEGORY_CACHE_VERSION_KEY) == 2
+
+
+@pytest.mark.django_db
+def test_bump_category_cache_version_falls_back_when_incr_not_supported(
+    monkeypatch,
+):
+    cache.clear()
+    cache.set(CATEGORY_CACHE_VERSION_KEY, 5)
+
+    def raise_not_implemented(_):
+        raise NotImplementedError
+
+    monkeypatch.setattr(category_cache.cache, "incr", raise_not_implemented)
+
+    category_cache.bump_category_cache_version()
+
+    assert cache.get(CATEGORY_CACHE_VERSION_KEY) == 6

--- a/backend/api/views/category.py
+++ b/backend/api/views/category.py
@@ -1,6 +1,11 @@
+from django.core.cache import cache
 from django.http import JsonResponse
 from django.views.decorators.http import require_GET
 
+from api.cache.category_cache import (
+    CATEGORY_CACHE_TTL_SECONDS,
+    get_categories_payload_cache_key,
+)
 from api.serializers.category_serializer import serialize_category
 from api.services.category_service import list_categories_for_user
 
@@ -10,11 +15,14 @@ def categories_collection(request):
     if not request.user.is_authenticated:
         return JsonResponse({"detail": "Authentication required"}, status=401)
 
+    cache_key = get_categories_payload_cache_key(user_id=request.user.id)
+    cached_payload = cache.get(cache_key)
+    if cached_payload is not None:
+        return JsonResponse(cached_payload)
+
     categories = list_categories_for_user(request.user)
-    return JsonResponse(
-        {
-            "categories": [
-                serialize_category(category) for category in categories
-            ]
-        }
-    )
+    payload = {
+        "categories": [serialize_category(category) for category in categories]
+    }
+    cache.set(cache_key, payload, CATEGORY_CACHE_TTL_SECONDS)
+    return JsonResponse(payload)


### PR DESCRIPTION
This pull request introduces category caching for the categories API, improving performance by reducing redundant database queries. It adds a cache versioning system that ensures cache invalidation when categories change, and includes comprehensive tests to verify the caching logic and its edge cases.

Close #20 

**Category Caching and Invalidation:**

* Added a new module `category_cache.py` that implements category caching with versioning, including functions to get/set the cache version and to bump the version when categories change.
* Modified the `categories_collection` view in `category.py` to use the cache: it now checks for a cached payload before querying the database and sets the cache after fetching categories. [[1]](diffhunk://#diff-2bb25a5ad4a75c606406138bcd6144b145571e64ea1e2c699cc7e4b809f78ac7R1-R8) [[2]](diffhunk://#diff-2bb25a5ad4a75c606406138bcd6144b145571e64ea1e2c699cc7e4b809f78ac7R18-R28)

**Cache Invalidation on Category Changes:**

* Added Django signal handlers in `signals.py` that automatically bump the cache version when a `Category` is created, updated, or deleted, ensuring the cache is invalidated appropriately. Also registered signals in the app config. [[1]](diffhunk://#diff-bc333e676da505d1153f897841d0aa99a341045d68bc02788df8885bb97bea80R1-R11) [[2]](diffhunk://#diff-3a7e682b1884e7300e6006cfc75c2d6f961ec2fda4ad8b948a30997fc46f54a4R7-R9)

**Testing and Reliability:**

* Extended `test_categories_api.py` with tests for caching behavior, cache version bumping, and fallback logic when the cache backend does not support increment operations. [[1]](diffhunk://#diff-eb2618d59045a6c7f7178f8cb99bf080fcec4b6a272f735ee35730060d6f8516R3-R9) [[2]](diffhunk://#diff-eb2618d59045a6c7f7178f8cb99bf080fcec4b6a272f735ee35730060d6f8516R52-R109)

**Possible Bug documentation:**
* It turns out that what was causing the double requests behavior was the reactStrictMode, so no bug to fix.